### PR TITLE
travis and makefile improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,6 @@ before-install:
 install: 
   - sudo apt-get install libev-dev libgoogle-perftools-dev libhiredis-dev libicu-dev libcurl4-openssl-dev libboost-dev libluajit-5.1-dev libpth-dev uuid-dev
   
-    
-  # Make fserv use the system-provided LuaJIT headers. (This is dirty...)
-  - cd ~/build
-  - lua_src=f-list/fserv/lib/lua/src
-  - mkdir -p $lua_src
-  - cp /usr/include/luajit-2.0/* $lua_src
-  - cp /usr/lib/x86_64-linux-gnu/libluajit-5.1.a $lua_src/libluajit.a
-  - cp /usr/lib/x86_64-linux-gnu/libluajit-5.1.so $lua_src/libluajit.so
-  
   # Get libjansson version 2.5, the one in Ubuntu 12.04's repos is way outdated.
   - cd ~/build
   - wget http://www.digip.org/jansson/releases/jansson-2.5.tar.gz

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,8 +9,8 @@ endif
 TARGETDIR= ../$(OUTDIR)
 INSTALLDIR= ../bin/
 
-CXXFLAGS+=	-Wall -Werror -fno-strict-aliasing -I/usr/local/include -I../lib/lua/src -I../lib/evhttp
-LDFLAGS+=	-L/usr/local/lib -L../lib/lua/src -L../lib/glog_install/lib -L../lib/evhttp -levhttpclient -lpthread -lrt -lev -lm -lluajit -lglog -ljansson -lcurl -lhiredis -licuuc -licudata -ltcmalloc -luuid
+CXXFLAGS+=	-Wall -Werror -fno-strict-aliasing -I/usr/include/luajit-2.0 -I/usr/local/include -I../lib/lua/src -I../lib/evhttp
+LDFLAGS+=	-L/usr/local/lib -L../lib/lua/src -L../lib/glog_install/lib -L../lib/evhttp -levhttpclient -lpthread -lrt -lev -lm -lluajit-5.1 -lglog -ljansson -lcurl -lhiredis -licuuc -licudata -ltcmalloc -luuid
 
 FSERV_O=	channel.o connection.o fserv.o login_evhttp.o lua_channel.o lua_chat.o lua_connection.o lua_constants.o messagebuffer.o native_command.o redis.o server.o server_state.o startup_config.o unicode_tools.o websocket.o base64.o md5.o modp_b64.o sha1.o
 PRECOMP_GCH=	$(TARGETDIR)precompiled_headers.hpp.gch
@@ -26,7 +26,7 @@ $(TARGETDIR)%.o: %.cpp
 
 $(TARGETDIR)%.hpp.gch: %.hpp
 	@echo "$(CXX)-precompile $@"
-	@${CXX} -g -I../lib/lua/src -Wall -Werror -fno-strict-aliasing -c $< -o $(TARGETDIR)$@
+	@${CXX} $(CXXFLAGS) -c $< -o $(TARGETDIR)$@
 
 %.lua:
 	@echo "copy ../script/$@ to $(TARGETDIR)script/$@"


### PR DESCRIPTION
This PR removes the need to directly copy luajit into the desired places,
and runs by just referencing the include directories and proper library directly.

It also uses the proper flags to get the precompiled headers in
the right place.
