### PR TITLE
Only try to apply proxy url if there's an x-forwarded-for header

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -313,7 +313,7 @@ void Server::handshakeCallback(struct ev_loop* loop, ev_io* w, int revents) {
 
             }
             // Only localhost is allowed to proxy for other clients.
-            if (ntohl(con->clientAddress.sin_addr.s_addr) == 0x7f000001) {
+            if (ip.size() && ntohl(con->clientAddress.sin_addr.s_addr) == 0x7f000001) {
                 if (inet_pton(AF_INET, ip.c_str(), &con->clientAddress.sin_addr) != 1) {
                     LOG(WARNING) << "Could not determine the endpoint address from the TLS proxy.";
                     prepareShutdownConnection(con.get());


### PR DESCRIPTION
ip will still be "" if no forwarded header
this allows non-proxy clients to connect from localhost!